### PR TITLE
Sync selected repository folders to S3

### DIFF
--- a/.github/workflows/publish-to-s3.yaml
+++ b/.github/workflows/publish-to-s3.yaml
@@ -1,0 +1,32 @@
+name: Publish to S3
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::312560106906:role/hubverse-${{ github.event.repository.name }}-githubaction
+        aws-region: us-east-1
+
+    - name: Copy files to S3
+      run: |
+        aws s3 sync ./auxiliary-data s3://hubverse-${{ github.event.repository.name }}/auxiliary-data --delete
+        aws s3 sync ./hub-config s3://hubverse-${{ github.event.repository.name }}/hub-config --delete
+        aws s3 sync ./model-metadata s3://hubverse-${{ github.event.repository.name }}/model-metadata --delete
+        aws s3 sync ./model-output s3://hubverse-${{ github.event.repository.name }}/model-output --delete
+        aws s3 sync ./target-data s3://hubverse-${{ github.event.repository.name }}/target-data --delete

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,9 +21,11 @@ This repository is designed as an example modeling Hub that follows the infrastr
 
 The example model outputs that are provided here are adapted from forecasts submitted to the FluSight Forecast Hub for the 2022/23 season. The original forecasts were provided in quantile format, but they have been modified to provide examples of additional model output types and targets. They should be viewed only as illustrations of the data formats, not as realistic examples of forecasts. **Note that the folder `internal-data-raw` is not a part of the standard hub setup; it contains the original source data and scripts used to create the example model output data and target data.**
 
-## Working with the data
+## Working with the data in R
 
-To work with the data in R, you can use code like the following:
+Install the [hubUtils package](https://infectious-disease-modeling-hubs.github.io/hubUtils/) to work with the data in R.
+
+To connect to a local copy of the data, clone this repository and use code like the following:
 
 ```{r}
 library(hubUtils)
@@ -43,5 +45,34 @@ head(inc_flu_hosp_target_data)
 
 rate_category_target_data <- read.csv(
   "target-data/wk-flu-hosp-rate-category-target-values.csv")
+head(rate_category_target_data)
+```
+
+
+To connect to a copy of this example data hosted in the cloud (on AWS S3), your code would look like this:
+
+```{r}
+library(aws.s3)
+library(dplyr)
+library(hubUtils)
+
+hub_path <- s3_bucket("hubverse-example-complex-forecast-hub")
+model_outputs <- hubUtils::connect_hub(hub_path) %>%
+  dplyr::collect()
+head(model_outputs)
+
+target_time_series_data <- aws.s3::s3read_using(
+  read.csv,
+  object = "s3://hubverse-example-complex-forecast-hub/target-data/flu-hospitalization-time-series.csv")
+head(target_time_series_data)
+
+inc_flu_hosp_target_data <- aws.s3::s3read_using(
+  read.csv,
+  object = "s3://hubverse-example-complex-forecast-hub/target-data/wk-inc-flu-hosp-target-values.csv")
+head(inc_flu_hosp_target_data)
+
+rate_category_target_data <- aws.s3::s3read_using(
+  read.csv,
+  object = "s3://hubverse-example-complex-forecast-hub/target-data/wk-flu-hosp-rate-category-target-values.csv")
 head(rate_category_target_data)
 ```


### PR DESCRIPTION
resolves #12 

When there's a push to the main branch (i.e., when a PR is merged), sync data in the following folders to S3:

* auxiliary-data
* hub-config
* model-metadata
* model-output
* target-data

The bucket name is hubverse-[name-of-repo]: `s3://hubverse-example-complex-forecast-hub`