### PR TITLE
fix broken links in README files

### DIFF
--- a/model-metadata/README.md
+++ b/model-metadata/README.md
@@ -1,5 +1,5 @@
 # Model metadata
 
-This folder should contain metadata files for the models submitting to the hub, following the recommended [model metadata guidelines in our documentation](https://hubdocs.readthedocs.io/en/latest/format/model-metadata.html).
+This folder should contain metadata files for the models submitting to the hub, following the recommended [model metadata guidelines in our documentation](https://hubdocs.readthedocs.io/en/latest/user-guide/model-metadata.html).
 
 Since some metadata fields may be specific to this hub, creators of the hub are encouraged to modify the template model metadata file so that it is a valid model metadata file for your project.

--- a/model-output/README.md
+++ b/model-output/README.md
@@ -1,3 +1,3 @@
 # Model outputs folder
 
-This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://hubdocs.readthedocs.io/en/latest/format/model-output.html).
+This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://hubdocs.readthedocs.io/en/latest/user-guide/model-output.html).


### PR DESCRIPTION
It seems the hubverse documentation site has slightly changed how things are named, so the links in the README files in the `model_output` and `model-metadata` folders were not working. Updated paths here should be working again.