### PR TITLE
Fix name of the IAM role to be assumed by GitHub actions

### DIFF
--- a/.github/workflows/publish-to-s3.yaml
+++ b/.github/workflows/publish-to-s3.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: arn:aws:iam::767397675902:role/hubverse-${{ github.event.repository.name }}-githubaction-role
+        role-to-assume: arn:aws:iam::767397675902:role/${{ github.event.repository.name }}-githubaction-role
         aws-region: us-east-1
 
     - name: Copy files to S3


### PR DESCRIPTION
This is a follow up to #17 (which used the wrong naming convention for the IAM role name). To ensure that the GitHub `publish-to-S3.yaml` action continued to work while I was OOO, I manually changed the policy name via the AWS console, but have now changed it back to the name generated by our Infrastructure As Code experiment (https://github.com/Infectious-Disease-Modeling-Hubs/hubverse-infrastructure)

Below is the Pulumi output that shows the name change (_i.e._, role name changed from `hubverse-example-complex-forecast-hub-githubaction-role` to `example-comple-forecast-hub-githubaction-role` and a new "policy attachment" was created to apply permissions to the newly-renamed role)

![image](https://github.com/Infectious-Disease-Modeling-Hubs/example-complex-forecast-hub/assets/540544/2f1bb413-1bae-40c5-90f4-211cb1732faa)

