### PR TITLE
Point model-metadata README to local repo

### DIFF
--- a/hub-config/model-metadata-schema.json
+++ b/hub-config/model-metadata-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Schema for Modeling Hub model metadata",
-    "description": "This is the schema for model metadata files, please refer to https://github.com/cdcepi/FluSight-forecast-hub/blob/main/model-metadata/README.md for more information.",
+    "description": "This is the schema for model metadata files, please refer to https://github.com/Infectious-Disease-Modeling-Hubs/example-complex-forecast-hub/blob/main/model-metadata/README.md for more information.",
     "type": "object",
     "properties": {
         "team_name": {


### PR DESCRIPTION
This follows up #22 and updates the README link in the model-metadata schema to point to the README in this repo (instead of a link in the cdcepi org that we don't control).

Another follow-up question: would we consider finding a home for model-metadata/README.md in hubDocs (so that we have a central location for all example hubs to link to)?