### PR TITLE
Simplify sample target-values data

### DIFF
--- a/internal-data-raw/create_target_data.R
+++ b/internal-data-raw/create_target_data.R
@@ -159,5 +159,10 @@ target_data_distinct <- bind_rows(
     filter(output_type != "quantile")
 )
 
+# drop reference_date and horizon columns
+target_data_distinct <- target_data_distinct |>
+  select(-reference_date, -horizon) |>
+  distinct()
+
 write_csv(target_data_distinct,
           file = "target-data/target-values.csv")


### PR DESCRIPTION
Include only the distinct rows in target-values.csv after removing the reference_date and horizon columns. We determined those columns aren't needed and create extra noise.