### PR TITLE
Update validate-submission.yaml

### DIFF
--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -9,19 +9,24 @@ on:
       - 'model-metadata/*'
       - '!**README**'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   validate-submission:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
           use-public-rspm: true
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - name: Update R
         run: |
@@ -29,7 +34,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: Infectious-Disease-Modeling-Hubs/hubValidations, any::sessioninfo
+          packages: |
+            any::hubValidations
+            any::sessioninfo
 
       - name: Run validations
         env:


### PR DESCRIPTION
This workflow is deprecated. This PR replaces it with current workflow version. It isn't running properly because R no longer exists on the latest ubuntu-latest image so currently the solution is to pin to the ubuntu-22.04 version. Also added another fix for specifying workflow permissions.