### PR TITLE
Potential fix for code scanning alerts no. 3-5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -11,6 +11,8 @@ jobs:
   build-deps-cache-on-main:
     if: github.repository_owner == 'hubverse-org'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/hubverse-org/example-complex-forecast-hub/security/code-scanning/5](https://github.com/hubverse-org/example-complex-forecast-hub/security/code-scanning/5)

This workflow has continuously been skipped, then began failing with the merging of #64. We need to give it read permissions for it to work again (it seems like when we first added this workflow to the repository, we hadn't yet implemented restrictions on what permissions workflows had)

---

From Copilot:

> In general, the fix is to explicitly restrict the permissions of the `GITHUB_TOKEN` by adding a `permissions` key with least-privilege settings. This can be added at the workflow root (applies to all jobs) or at the job level. Since the snippet shows only one job, adding `permissions` under that job is sufficient and minimally invasive.
> 
> The best fix here is to add a `permissions` section to the `build-deps-cache-on-main` job with `contents: read`, which is the minimal permission CodeQL suggests and is enough for `actions/checkout` and reading the repository. No existing steps perform any GitHub write operations, so no additional permissions are needed. Concretely, in `.github/workflows/cache-deps.yaml`, under `jobs: build-deps-cache-on-main:`, insert:
> 
> ```yaml
> permissions:
>   contents: read
> ```
> 
> with indentation aligned to other job-level keys like `runs-on:` and `env:`. No imports or extra methods are needed, since this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
